### PR TITLE
Add remove-audio.com - free browser-based audio remover

### DIFF
--- a/README.md
+++ b/README.md
@@ -845,3 +845,6 @@ Tools for picking, analyzing, or seeing colors.
 *   [webfieldmanual.com](https://webfieldmanual.com) - A curated list of resources focused on documenting only the best knowledge for designing experiences and interfaces on the web.
 * [altctrls.info](http://altctrls.info) - Open and collaborative list of resources for making alternative controllers and playful installations.
 * [Game Making Tools Wiki](https://www.gamemaking.tools/wiki/) - Wiki with resources for amateur game makers. Open-source, fun-to-use, and unerappreciated stuff especially.
+
+
+* [Remove audio from video](https://remove-audio.com) - Free, browser-based audio remover. Local processing via WebAssembly. No signup, no watermarks. Batch up to 20 clips.


### PR DESCRIPTION
This adds https://remove-audio.com to the list.

It is a free, browser-based tool that strips audio from video files using FFmpeg.wasm and WebAssembly. All processing is local - no files are uploaded to any server. No signup, no watermarks, batch support for up to 20 clips.

Fits this list because: it is a free web tool for video processing.